### PR TITLE
Prepare Velorn v0.3.30

### DIFF
--- a/docs/RELEASE_NOTES_0.3.30.md
+++ b/docs/RELEASE_NOTES_0.3.30.md
@@ -1,0 +1,33 @@
+# Velorn v0.3.30
+
+Velorn v0.3.30 adds an extensible interface-localization system and the first broad Japanese-language experience across the editor's most-used workflows.
+
+## New
+
+- **Initial Japanese interface.** Select `日本語` in `Settings > Language` to use Japanese across the project hub, editor shell, Timeline, Effects, Generate, Stock/Pexels, workflow setup, Settings, Export, and PNG image-sequence export.
+- **Automatic locale detection and persistence.** Velorn recognizes supported system/browser locales on first use and remembers the creator's selected language across restarts.
+- **Extensible language packs.** Interface languages now load from a small manifest and JSON dictionaries, making it possible to add more languages without adding a new JavaScript dependency or hard-wiring each language into the application.
+- **Localization contributor guide.** The new `docs/LOCALIZATION.md` guide documents how to register a language, translate interface keys, preserve technical identifiers, and run the localization checks.
+
+## Improved
+
+- **Safe English fallback.** Missing translated strings fall back to English so language coverage can grow incrementally without exposing raw translation keys or making a workflow unusable.
+- **Resilient dictionary loading.** Velorn waits for its English dictionary before rendering the application and provides a retry state if that required file cannot load.
+- **Protected technical values.** Workflow names, model names, codecs, file paths, effect IDs, and keyboard bindings remain unchanged where translating them could break behavior or make troubleshooting harder.
+
+## Notes
+
+- This is the **initial** Japanese localization. Portions of major workflows, along with lower-traffic and highly technical surfaces, still appear in English and can be translated incrementally.
+- Switching languages does not rewrite existing project files, media, workflow identifiers, or generated content.
+- Thank you to [@ufotone](https://github.com/ufotone) for contributing the localization foundation and Japanese translation.
+
+## Downloads
+
+- `Windows Installer`: standard Windows install experience for most users
+- `Windows Portable`: no-install Windows build for quick testing or portable use
+- `Mac (Apple Silicon)`: for M1, M2, M3, M4, and newer Macs
+- `Mac (Intel)`: for older Intel-based Macs
+- `Linux AppImage`: portable Linux build
+- `Linux deb`: Debian/Ubuntu package
+
+Ignore the auto-generated source-code archives unless you plan to build Velorn from source.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "velorn",
-  "version": "0.3.29",
+  "version": "0.3.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "velorn",
-      "version": "0.3.29",
+      "version": "0.3.30",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@xyflow/react": "^12.10.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "velorn",
-  "version": "0.3.29",
+  "version": "0.3.30",
   "description": "AI-native video editing built around real creative timelines, generative workflows, and local agent control.",
   "main": "electron/main.js",
   "scripts": {


### PR DESCRIPTION
## Summary

- bump Velorn from 0.3.29 to 0.3.30
- add release notes for the initial Japanese interface localization
- keep PR #107 and the Electron upgrade outside this release

## Verification

- all 19 existing test areas passed (160 tests)
- `npm run build`
- Electron main/preload/MCP syntax checks
- `npm run electron:pack`
- packaged Ubuntu app switched to Japanese and retained the choice after restart
- packaged app reports version 0.3.30 and contains all three language assets
- `git diff --check`

## Contributor License Agreement

- [x] I have read and agree to the Contributor License Agreement in `CONTRIBUTOR_LICENSE_AGREEMENT.md`, and I have the right to submit this contribution.
