### PR TITLE
Prepare Velorn v0.3.31

### DIFF
--- a/docs/RELEASE_NOTES_0.3.31.md
+++ b/docs/RELEASE_NOTES_0.3.31.md
@@ -1,0 +1,39 @@
+# Velorn v0.3.31
+
+Velorn v0.3.31 adds animated GIF round trips, a built-in place to discover community work and tutorials, and faster timeline navigation with configurable zoom shortcuts.
+
+## New
+
+- **Animated GIF import.** Import an animated GIF from the Assets panel, drag and drop, MCP, or supported generation results and use it as editable timeline media. Velorn preserves the animation timing and creates project-owned playback media for reliable scrubbing, trimming, compositing, and export. Static GIFs remain regular image assets.
+- **Optimized GIF export.** Export the timeline or selected range as a continuously looping GIF with adjustable resolution and frame rate. Velorn uses an optimized 256-color palette for better quality and more practical file sizes.
+- **Discover Velorn creations and tutorials.** The new Discover resource brings together Featured videos, work made by the Velorn community, and practical tutorials. Videos use click-to-load YouTube playback so the player is not loaded until you choose to watch.
+- **Submit work for the showcase.** Creators can submit a YouTube video from Discover with attribution and explicit rights/featuring permission. Submissions go through review and are never published automatically.
+- **Timeline zoom hotkeys.** Use `1` to frame all timeline content, `2` to zoom out, and `3` to zoom in. All three actions can be changed or cleared in `Settings > Hotkeys`.
+
+## Improved
+
+- **A clearly separate Discover resource.** Discover appears after Export with its own visual treatment, remains available from the Welcome screen, and can be hidden at any time in `Settings > Appearance`.
+- **Resilient Discover catalog.** Velorn can refresh the curated catalog independently while retaining a validated bundled fallback for offline or unavailable-network situations.
+- **Safer animated GIF handling.** Import validates GIF structure and resource bounds, preserves transparent animations with alpha-capable project media, avoids unsafe cache conversions, and cleans up interrupted native conversions.
+- **Reliable GIF export cancellation.** Two-pass palette generation and encoding are cancellable, temporary output is cleaned safely, and an existing destination is preserved if export fails.
+- **Export settings remain intact.** Switching to GIF and back no longer resets the saved codec, quality, audio, hardware-encoding, direct-pipe, upscale, resolution, or frame-rate choices used by regular video exports.
+- **Expanded showcase.** Discover now includes eight curated videos, including two additional AI music videos made with Velorn.
+- **English and Japanese coverage.** New Discover and GIF controls include matching English and Japanese interface text.
+
+## Notes
+
+- Animated GIFs are normalized into project-owned video media on import. Seeing an `.mp4` or alpha-capable `.webm` inside the project media folder is expected; the original GIF name and source details remain attached to the asset.
+- GIF export is currently opaque, audio-free, and set to loop continuously. High resolutions and frame rates can create very large GIF files, so moderate settings are recommended.
+- Watching Discover videos requires an internet connection. Thumbnails come from YouTube, and the embedded player loads only after you select a video.
+- Existing custom hotkey assignments take priority during migration. If `1`, `2`, or `3` was already assigned, the new conflicting default is left unassigned rather than replacing the creator's binding.
+
+## Downloads
+
+- `Windows Installer`: standard Windows install experience for most users
+- `Windows Portable`: no-install Windows build for quick testing or portable use
+- `Mac (Apple Silicon)`: for M1, M2, M3, M4, and newer Macs
+- `Mac (Intel)`: for older Intel-based Macs
+- `Linux AppImage`: portable Linux build
+- `Linux deb`: Debian/Ubuntu package
+
+Ignore the auto-generated source-code archives unless you plan to build Velorn from source.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "velorn",
-  "version": "0.3.30",
+  "version": "0.3.31",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "velorn",
-      "version": "0.3.30",
+      "version": "0.3.31",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@xyflow/react": "^12.10.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "velorn",
-  "version": "0.3.30",
+  "version": "0.3.31",
   "description": "AI-native video editing built around real creative timelines, generative workflows, and local agent control.",
   "main": "electron/main.js",
   "scripts": {


### PR DESCRIPTION
## Summary

Prepares Velorn v0.3.31 after the reviewed Discover/GIF feature merge.

- Bumps `package.json` and both lockfile version fields to `0.3.31`.
- Adds complete v0.3.31 release notes covering timeline zoom hotkeys, Discover, animated GIF import/export, platform downloads, and current limitations.

## Testing

- [x] I ran `npm run build`
- [x] I smoke-tested the area I changed
- [x] I updated docs when behavior, setup, onboarding, or release steps changed

Before this release PR, all 24 package test scripts passed, Electron syntax checks passed, Linux unpacked packaging passed on the workflow's Node 20 baseline, and the maintainer manually verified the combined Discover/GIF behavior. On this exact versioned tree, the production build and focused Discover, GIF import/export, hotkey, and localization suites pass.

## Contributor License Agreement

- [x] I have read and agree to the Contributor License Agreement in `CONTRIBUTOR_LICENSE_AGREEMENT.md`, and I have the right to submit this contribution.

## Notes

- The intended tag is `v0.3.31` after this PR is merged.
- GitHub Actions will build the Windows installer/portable app, both macOS DMGs, Linux AppImage, and Linux deb into a draft release for manual review before publication.
