### PR TITLE
Fix RIFE build on modern CMake

### DIFF
--- a/scripts/rife-runtime/build.py
+++ b/scripts/rife-runtime/build.py
@@ -382,6 +382,7 @@ def configure_and_build(
         "-G",
         args.generator,
         "-DCMAKE_BUILD_TYPE=Release",
+        "-DCMAKE_POLICY_VERSION_MINIMUM=3.5",
         "-DCMAKE_SKIP_RPATH=ON",
         "-DUSE_SYSTEM_NCNN=OFF",
         "-DNCNN_SYSTEM_GLSLANG=OFF",

--- a/tests/rifeRuntimeSourceBuild.test.js
+++ b/tests/rifeRuntimeSourceBuild.test.js
@@ -183,6 +183,11 @@ test('builder forces LF source checkouts instead of inheriting Windows autocrlf'
   assert.doesNotMatch(source, /\b(?:str|Path) \| (?:str|Path|None)\b/)
 })
 
+test('builder enables the pinned ncnn source on modern CMake releases', () => {
+  const source = fs.readFileSync(scriptPath, 'utf8')
+  assert.match(source, /-DCMAKE_POLICY_VERSION_MINIMUM=3\.5/)
+})
+
 test('macOS plan resolves the pinned static MoltenVK archive layout', (t) => {
   const temporary = fs.mkdtempSync(path.join(os.tmpdir(), 'velorn-moltenvk-layout-test-'))
   t.after(() => fs.rmSync(temporary, { recursive: true, force: true }))


### PR DESCRIPTION
## Summary

- opt the pinned, audited ncnn source into CMake's retained 3.5 compatibility policy
- keep the source pin unchanged while allowing current GitHub macOS runners to configure it
- add a focused regression check for the required compatibility flag

## Verification

- `node --test ./tests/rifeRuntimeSourceBuild.test.js`
- `python3 -m py_compile scripts/rife-runtime/build.py`
- `git diff --check`

## Contributor License Agreement

- [x] I have read and agree to the Contributor License Agreement in `CONTRIBUTOR_LICENSE_AGREEMENT.md`, and I have the right to submit this contribution.
