### PR TITLE
Fix macOS RIFE dependency audit

### DIFF
--- a/scripts/rife-runtime/build.py
+++ b/scripts/rife-runtime/build.py
@@ -526,6 +526,14 @@ def validate_linux_abi(output: str) -> dict[str, str]:
     return {"glibcRequired": glibc, "glibcxxRequired": glibcxx}
 
 
+def parse_macos_dependency_output(otool_output: str) -> str:
+    """Remove otool's inspected-file header and retain linked libraries only."""
+    lines = otool_output.splitlines()
+    if lines and lines[0].strip().endswith(":"):
+        lines = lines[1:]
+    return "\n".join(lines)
+
+
 def audit_binary(
     executable: Path,
     work_dir: Path,
@@ -559,7 +567,9 @@ def audit_binary(
         expected = "x86_64" if arch == "x64" else "arm64"
         if architectures != [expected]:
             raise BuildError(f"macOS runtime architecture mismatch: expected {expected}, got {architectures}")
-        dependency_output = run([otool, "-L", executable], capture=True)
+        dependency_output = parse_macos_dependency_output(
+            run([otool, "-L", executable], capture=True)
+        )
         metadata.update({"architecture": expected, "inspector": Path(otool).name})
     elif platform_name == "win32":
         dumpbin = shutil.which("dumpbin")

--- a/tests/rifeRuntimeSourceBuild.test.js
+++ b/tests/rifeRuntimeSourceBuild.test.js
@@ -210,6 +210,26 @@ test('builder enables the pinned ncnn source on modern CMake releases', () => {
   assert.match(source, /-DCMAKE_POLICY_VERSION_MINIMUM=3\.5/)
 })
 
+test('macOS dependency audit ignores the inspected-file otool header', () => {
+  const probe = [
+    'import importlib.util, sys',
+    'spec = importlib.util.spec_from_file_location("velorn_rife_builder", sys.argv[1])',
+    'module = importlib.util.module_from_spec(spec)',
+    'spec.loader.exec_module(module)',
+    'print(module.parse_macos_dependency_output(sys.argv[2]))',
+  ].join('; ')
+  const otoolOutput = [
+    '/private/tmp/velorn-rife/cmake-build/rife-ncnn-vulkan:',
+    '\t/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 1800.65.0)',
+  ].join('\n')
+  const result = spawnSync('python3', ['-c', probe, scriptPath, otoolOutput], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  })
+  assert.equal(result.status, 0, result.stderr)
+  assert.equal(result.stdout.trim(), otoolOutput.split('\n')[1].trim())
+})
+
 test('macOS plan resolves the pinned static MoltenVK archive layout', (t) => {
   const temporary = fs.mkdtempSync(path.join(os.tmpdir(), 'velorn-moltenvk-layout-test-'))
   t.after(() => fs.rmSync(temporary, { recursive: true, force: true }))


### PR DESCRIPTION
## Summary

- ignore `otool -L`'s inspected-file header when auditing macOS runtime dependencies
- continue rejecting real build-directory dependency paths and unsafe linked libraries
- add a regression fixture using representative macOS `otool` output

## Verification

- `npm run test:rife-hardening` (42 passed, 1 expected hardware-runtime skip)
- `python3 -m py_compile scripts/rife-runtime/build.py`
- `git diff --check`

## Contributor License Agreement

- [x] I have read and agree to the Contributor License Agreement in `CONTRIBUTOR_LICENSE_AGREEMENT.md`, and I have the right to submit this contribution.
