### PR TITLE
Fix cross-platform release audits

### DIFF
--- a/package.json
+++ b/package.json
@@ -193,15 +193,7 @@
       }
     },
     "mac": {
-      "target": [
-        {
-          "target": "dmg",
-          "arch": [
-            "x64",
-            "arm64"
-          ]
-        }
-      ],
+      "target": "dmg",
       "icon": "build/icon.icns",
       "category": "public.app-category.video",
       "artifactName": "${productName}-${version}-mac-${arch}.${ext}",

--- a/scripts/rife-runtime/build.py
+++ b/scripts/rife-runtime/build.py
@@ -534,6 +534,12 @@ def parse_macos_dependency_output(otool_output: str) -> str:
     return "\n".join(lines)
 
 
+def parse_windows_dependency_output(inspector_output: str) -> str:
+    """Retain imported DLL names without inspector headers or input paths."""
+    dependencies = re.findall(r"[A-Za-z0-9_.+-]+\.dll\b", inspector_output, re.IGNORECASE)
+    return "\n".join(dict.fromkeys(dependencies))
+
+
 def audit_binary(
     executable: Path,
     work_dir: Path,
@@ -577,17 +583,23 @@ def audit_binary(
         objdump = shutil.which("objdump")
         if dumpbin:
             header = run([dumpbin, "/HEADERS", executable], capture=True)
-            dependency_output = run([dumpbin, "/DEPENDENTS", executable], capture=True)
+            dependency_output = parse_windows_dependency_output(
+                run([dumpbin, "/DEPENDENTS", executable], capture=True)
+            )
             valid_arch = "machine (x64)" in header.lower()
             inspector = "dumpbin"
         elif llvm_readobj:
             header = run([llvm_readobj, "--file-headers", executable], capture=True)
-            dependency_output = run([llvm_readobj, "--needed-libs", executable], capture=True)
+            dependency_output = parse_windows_dependency_output(
+                run([llvm_readobj, "--needed-libs", executable], capture=True)
+            )
             valid_arch = "x86_64" in header.lower()
             inspector = "llvm-readobj"
         elif objdump:
             header = run([objdump, "-f", executable], capture=True)
-            dependency_output = run([objdump, "-p", executable], capture=True)
+            dependency_output = parse_windows_dependency_output(
+                run([objdump, "-p", executable], capture=True)
+            )
             valid_arch = "pei-x86-64" in header.lower() or "i386:x86-64" in header.lower()
             inspector = "objdump"
         else:

--- a/tests/rifeRuntimeSourceBuild.test.js
+++ b/tests/rifeRuntimeSourceBuild.test.js
@@ -231,6 +231,30 @@ test('macOS dependency audit ignores the inspected-file otool header', () => {
   assert.equal(result.stdout.trim(), otoolOutput.split('\n')[1].trim())
 })
 
+test('Windows dependency audit ignores inspector headers and build paths', () => {
+  const probe = [
+    'import importlib.util, sys',
+    'spec = importlib.util.spec_from_file_location("velorn_rife_builder", sys.argv[1])',
+    'module = importlib.util.module_from_spec(spec)',
+    'spec.loader.exec_module(module)',
+    'print(module.parse_windows_dependency_output(sys.argv[2]))',
+  ].join('; ')
+  const inspectorOutput = [
+    'File: D:\\a\\_temp\\vrife\\cmake-build\\Release\\rife-ncnn-vulkan.exe',
+    'NeededLibraries [',
+    '  KERNEL32.dll',
+    '  vulkan-1.dll',
+    ']',
+  ].join('\n')
+  const result = spawnSync('python3', ['-c', probe, scriptPath, inspectorOutput], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  })
+  assert.equal(result.status, 0, result.stderr)
+  assert.equal(result.stdout.trim(), ['KERNEL32.dll', 'vulkan-1.dll'].join('\n'))
+  assert.doesNotMatch(result.stdout, /vrife|cmake-build/i)
+})
+
 test('macOS plan resolves the pinned static MoltenVK archive layout', (t) => {
   const temporary = fs.mkdtempSync(path.join(os.tmpdir(), 'velorn-moltenvk-layout-test-'))
   t.after(() => fs.rmSync(temporary, { recursive: true, force: true }))


### PR DESCRIPTION
## Summary

- keep each macOS release job on its requested architecture
- ignore inspector headers when auditing Windows runtime dependencies
- add regression coverage for the Windows dependency parser

## Verification

- [x] `node --test tests/rifeRuntimeSourceBuild.test.js`
- [x] `npm run test:rife-hardening`
- [x] `npm run build`
- [x] `git diff --check`

## Contributor License Agreement

- [x] I have read and agree to the Contributor License Agreement in `CONTRIBUTOR_LICENSE_AGREEMENT.md`, and I have the right to submit this contribution.
