### PR TITLE
Fix Windows signature verification environment

### DIFF
--- a/electron/rifeRuntime.js
+++ b/electron/rifeRuntime.js
@@ -274,6 +274,17 @@ function readMacSigningIdentity(filePath) {
   return { teamIdentifier, identifier }
 }
 
+function windowsSignatureEnvironment(environment = process.env) {
+  const result = { ...environment }
+  // GitHub Actions launches electron-builder from PowerShell 7, whose module
+  // path is not compatible with the Windows PowerShell process used below.
+  // Omitting it lets powershell.exe restore its native built-in module paths.
+  for (const key of Object.keys(result)) {
+    if (key.toLowerCase() === 'psmodulepath') delete result[key]
+  }
+  return result
+}
+
 function readWindowsSigningIdentities(targetPath, hostExecutablePath) {
   const script = [
     "$ErrorActionPreference = 'Stop'",
@@ -299,7 +310,7 @@ function readWindowsSigningIdentities(targetPath, hostExecutablePath) {
     '-Command', script,
   ], {
     env: {
-      ...process.env,
+      ...windowsSignatureEnvironment(),
       VELORN_RIFE_SIGNATURE_TARGET: targetPath,
       VELORN_RIFE_SIGNATURE_HOST: hostExecutablePath || '',
     },
@@ -662,4 +673,5 @@ module.exports = {
   sha256File,
   validateRifeRuntime,
   verifyPlatformSignature,
+  windowsSignatureEnvironment,
 }

--- a/tests/rifeRuntime.test.js
+++ b/tests/rifeRuntime.test.js
@@ -4,7 +4,7 @@ const fs = require('fs')
 const os = require('os')
 const path = require('path')
 
-const { resolveRifeRuntime } = require('../electron/rifeRuntime')
+const { resolveRifeRuntime, windowsSignatureEnvironment } = require('../electron/rifeRuntime')
 
 function createRuntime(root, platform = 'linux') {
   fs.mkdirSync(path.join(root, 'rife-v4.6'), { recursive: true })
@@ -52,4 +52,16 @@ test('reports a missing model or executable without guessing another path', (t) 
   assert.equal(result.available, false)
   assert.equal(result.missingPaths.length, 3)
   assert.match(result.error, /smooth-motion engine is missing/i)
+})
+
+test('Windows signature checks discard incompatible inherited PowerShell module paths', () => {
+  const environment = windowsSignatureEnvironment({
+    Path: 'C:\\Windows\\System32',
+    PSModulePath: 'C:\\Program Files\\PowerShell\\Modules',
+    pSmOdUlEpAtH: 'C:\\another-inherited-module-path',
+    VELORN_TEST_VALUE: 'preserved',
+  })
+  assert.equal(environment.Path, 'C:\\Windows\\System32')
+  assert.equal(environment.VELORN_TEST_VALUE, 'preserved')
+  assert.equal(Object.keys(environment).some((key) => key.toLowerCase() === 'psmodulepath'), false)
 })


### PR DESCRIPTION
## Summary

- prevent PowerShell 7 module paths from leaking into the Windows PowerShell signature verifier
- preserve the remaining child-process environment
- add focused environment regression coverage

## Verification

- [x] `node --check electron/rifeRuntime.js`
- [x] `node --test tests/rifeRuntime.test.js tests/runtimePackageGate.test.js`
- [x] `npm run test:rife-hardening`
- [x] `npm run build`
- [x] `git diff --check`

## Contributor License Agreement

- [x] I have read and agree to the Contributor License Agreement in `CONTRIBUTOR_LICENSE_AGREEMENT.md`, and I have the right to submit this contribution.
